### PR TITLE
Replace cargo-xbuild with build-std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlibc"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "system76_ecflash"
 version = "0.1.1"
 source = "git+https://github.com/system76/ecflash.git#fc3f098fda1c1f0707ac2f339f1cb760ff7376bb"
@@ -98,6 +103,7 @@ dependencies = [
  "redox_hwio 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_uefi 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_uefi_std 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "system76_ecflash 0.1.1 (git+https://github.com/system76/ecflash.git)",
  "system76_ectool 0.1.3 (git+https://github.com/system76/ec.git)",
 ]
@@ -114,5 +120,6 @@ dependencies = [
 "checksum redox_uefi 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dafc50645c27c55ca19d27645a6d91e2a8cbc7aabb2ed024ce914512c75e1217"
 "checksum redox_uefi_alloc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72e7224e2106fdc2a35a33e38825f4867c3566671dc496fb67b992d05328e564"
 "checksum redox_uefi_std 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ead5c13a8a650646b2f93065002d65b45226cdbc6494b0ac4aaed30ce9b17c7f"
+"checksum rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
 "checksum system76_ecflash 0.1.1 (git+https://github.com/system76/ecflash.git)" = "<none>"
 "checksum system76_ectool 0.1.3 (git+https://github.com/system76/ec.git)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,6 @@ name = "system76_firmware_update"
 version = "1.0.0"
 edition = "2018"
 
-[package.metadata.cargo-xbuild]
-memcpy = true
-sysroot_path = "build/xbuild"
-
 [lib]
 name = "system76_firmware_update"
 path = "src/lib.rs"
@@ -20,6 +16,7 @@ redox_dmi = "0.1.5"
 redox_hwio = "0.1.0"
 redox_uefi = "0.1.0"
 redox_uefi_std = "0.1.1"
+rlibc = "1.0"
 system76_ecflash = { git = "https://github.com/system76/ecflash.git" }
 system76_ectool = { git = "https://github.com/system76/ec.git" }
 

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,8 @@ $(BUILD)/boot.o: $(BUILD)/boot.a
 $(BUILD)/boot.a: Cargo.lock Cargo.toml src/* src/*/*
 	mkdir -p $(BUILD)
 	rustup component add rust-src
-	cargo xrustc \
+	cargo rustc \
+		-Z build-std=core,alloc \
 		--lib \
 		--target $(TARGET) \
 		--release \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 #![feature(try_trait)]
 
 extern crate alloc;
-
+extern crate rlibc;
 #[macro_use]
 extern crate uefi_std as std;
 


### PR DESCRIPTION
Use [build-std](https://doc.rust-lang.org/cargo/reference/unstable.html#build-std) instead of cargo-xbuild. This requires adding a dependency on rlibc, since the `mem` feature of `compiler_builtins` cannot be enabled [\[1\]](https://github.com/rust-lang/cargo/pull/7216#issuecomment-529433594).