### PR TITLE
Convert toolchain file to TOML syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,6 @@ $(BUILD)/efi.img: $(BUILD)/boot.efi res/*
 
 $(BUILD)/boot.efi: Cargo.lock Cargo.toml src/* src/*/*
 	mkdir -p $(BUILD)
-	rustup component add rust-src
 	cargo rustc \
 		-Z build-std=core,alloc \
 		--target $(TARGET) \

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,3 @@
-nightly-2020-07-27
+[toolchain]
+channel = "nightly-2020-07-27"
+components = ["rust-src"]


### PR DESCRIPTION
rustup 1.23.0 (2020-11-27) introduced support for TOML syntax for the
toolchain file. Use this and specify required compoenents.

To ensure you are using a new enough rustup, run:

    rustup self update

Since we plan to add CI soon, this is potentially blocked by actions-rs/toolchain#126.