### PR TITLE
Oryp7 fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup Rust toolchain
-      run: |
-        rustup show
-        rustup component add rust-src clippy
+      run: rustup show
 
     - uses: actions-rs/clippy-check@v1
       env:
@@ -30,7 +28,6 @@ jobs:
       run: |
         sudo apt install --yes make mtools parted
         rustup show
-        rustup component add rust-src
 
     - name: Build UEFI application
       run: make

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2020-07-27"
-components = ["rust-src"]
+components = ["rust-src", "clippy"]

--- a/src/app/ec.rs
+++ b/src/app/ec.rs
@@ -603,7 +603,7 @@ impl Component for EcComponent {
                 }
             }
 
-            println!("EC will reset in 5 seconds");
+            println!("System will shut off in 5 seconds");
             let _ = (std::system_table().BootServices.Stall)(5_000_000);
 
             // Reset EC


### PR DESCRIPTION
This implements the legacy EC flashing protocol in firmware-update and uses it when flashing System76 EC on top of legacy EC so we can control when the EC gets reset.

This will affect any transitions between proprietary and open firmware, so other models should be tested as well.