### PR TITLE
FPT: Only flash DESC, ME, and BIOS regions

### DIFF
--- a/res/firmware.nsh
+++ b/res/firmware.nsh
@@ -74,10 +74,26 @@ if "%2" == "bios" then
         # Flash with FPT and exit if possible
         if exist fpt.efi then
             if exist fparts.txt then
-                fpt.efi -P "%1\fparts.txt" -F "%1\firmware.rom"
+                fpt.efi -P "%1\fparts.txt" -F "%1\firmware.rom" -DESC
+                if %lasterror% ne 0 then
+                    exit %lasterror%
+                endif
+                fpt.efi -P "%1\fparts.txt" -F "%1\firmware.rom" -ME
+                if %lasterror% ne 0 then
+                    exit %lasterror%
+                endif
+                fpt.efi -P "%1\fparts.txt" -F "%1\firmware.rom" -BIOS
                 exit %lasterror%
             else
-                fpt.efi -F "%1\firmware.rom"
+                fpt.efi -F "%1\firmware.rom" -DESC
+                if %lasterror% ne 0 then
+                    exit %lasterror%
+                endif
+                fpt.efi -F "%1\firmware.rom" -ME
+                if %lasterror% ne 0 then
+                    exit %lasterror%
+                endif
+                fpt.efi -F "%1\firmware.rom" -BIOS
                 exit %lasterror%
             endif
         endif


### PR DESCRIPTION
Only flash regions that we expect to update.

Platform Data and EC regions are unused. The GbE region, if used, should
not be modified to preserve MAC address, SSIDs, and OEM custom values
set when the chip was originally programmed.

- Do we have any firmware that uses the EC region?
- I only tested on the gaze16. Do any of the other boards lock these regions?

This only works when flashing from proprietary firmware.

On open firmware, FPT cannot be used to flash the regions:

- ME: Cannot find the ME client
- BIOS: Protected Range Registers are set, preventing flash access
