### PR TITLE
EC: Detect gaze16-3060 variant by LAN controller

### DIFF
--- a/src/app/ec.rs
+++ b/src/app/ec.rs
@@ -20,7 +20,7 @@ use std::{
 };
 use uefi::status::{Error, Result};
 
-use super::{ECROM, EC2ROM, ECTAG, FIRMWAREDIR, FIRMWARENSH, shell, Component};
+use super::{ECROM, EC2ROM, ECTAG, FIRMWAREDIR, FIRMWARENSH, pci_read, shell, Component};
 
 pub struct UefiTimeout {
     duration: u64,
@@ -155,7 +155,14 @@ impl EcComponent {
                 "N150CU" => "system76/darp6".to_string(),
                 "NH50DB" | "NH5xDC" => "system76/gaze15".to_string(),
                 "NH5xHX" => "system76/gaze16-3050".to_string(),
-                "NH5_7HPQ" => "system76/gaze16-3060".to_string(),
+                "NH5_7HPQ" => {
+                    // If the builtin ethernet at 00:1f.6 is present, this is a -b variant
+                    if pci_read(0x00, 0x1f, 0x6, 0x00).unwrap() == 0x15fa8086 {
+                        "system76/gaze16-3060-b".to_string()
+                    } else {
+                        "system76/gaze16-3060".to_string()
+                    }
+                },
                 "NS50MU" => "system76/darp7".to_string(),
                 "NV40Mx" | "NV40Mx-DV" => "system76/galp5".to_string(),
                 "PB50Ex" => "system76/addw1".to_string(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -28,10 +28,12 @@ use crate::text::TextDisplay;
 pub use self::bios::BiosComponent;
 pub use self::component::Component;
 pub use self::ec::EcComponent;
+pub use self::pci::pci_read;
 
 mod bios;
 mod component;
 mod ec;
+mod pci;
 
 static ECROM: &str = concat!("\\", env!("BASEDIR"), "\\firmware\\ec.rom");
 static ECTAG: &str = concat!("\\", env!("BASEDIR"), "\\firmware\\ec.tag");

--- a/src/app/pci.rs
+++ b/src/app/pci.rs
@@ -1,0 +1,19 @@
+use hwio::{Io, Pio};
+
+pub fn pci_read(bus: u8, dev: u8, func: u8, offset: u8) -> Result<u32, String> {
+    if dev > 0x1f {
+        return Err(format!("pci_read dev 0x{:x} is greater than 0x1f", dev));
+    }
+
+    if func > 0x7 {
+        return Err(format!("pci_read func 0x{:x} is greater than 0x7", func));
+    }
+
+    let address = 0x80000000 |
+        (u32::from(bus) << 16) |
+        (u32::from(dev) << 11) |
+        (u32::from(func) << 8) |
+        u32::from(offset);
+    Pio::<u32>::new(0xCF8).write(address);
+    Ok(Pio::<u32>::new(0xCFC).read())
+}


### PR DESCRIPTION
The proprietary firmware uses the same project name for both variants.
If the onboard GbE LAN controller (00:1f.6) is detected, use the `-b` variant name.

Fixes EC Mismatch error when flashing gaze16-3060-b.