### PR TITLE
Replace uefi dependency with std::uefi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,6 @@ dependencies = [
  "redox_dmi",
  "redox_hwio",
  "redox_intelflash",
- "redox_uefi",
  "redox_uefi_std",
  "system76_ecflash",
  "system76_ectool",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ plain = "0.2.3"
 redox_dmi = "0.1.5"
 redox_hwio = "0.1.4"
 redox_intelflash = "0.1.3"
-redox_uefi = "0.1.2"
 redox_uefi_std = "0.1.5"
 system76_ecflash = { git = "https://github.com/system76/ecflash.git" }
 system76_ectool = { git = "https://github.com/system76/ec.git", default-features = false, features = ["redox_hwio"] }

--- a/src/app/bios.rs
+++ b/src/app/bios.rs
@@ -10,8 +10,8 @@ use plain::Plain;
 use std::fs::{find, load};
 use std::ptr;
 use std::vars::{get_boot_item, get_boot_order, set_boot_item, set_boot_order};
-use uefi::reset::ResetType;
-use uefi::status::{Error, Result, Status};
+use std::uefi::reset::ResetType;
+use std::uefi::status::{Error, Result, Status};
 
 use super::{FIRMWARECAP, FIRMWAREDIR, FIRMWARENSH, FIRMWAREROM, H2OFFT, IFLASHV, UEFIFLASH, shell, Component};
 

--- a/src/app/component.rs
+++ b/src/app/component.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use uefi::status::Result;
+use std::uefi::status::Result;
 
 pub trait Component {
     fn name(&self) -> &str;

--- a/src/app/ec.rs
+++ b/src/app/ec.rs
@@ -18,7 +18,7 @@ use std::{
     fs::{find, load},
     str,
 };
-use uefi::status::{Error, Result};
+use std::uefi::{self, status::{Error, Result}};
 
 use super::{ECROM, EC2ROM, ECTAG, FIRMWAREDIR, FIRMWARENSH, pci_read, shell, Component};
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -17,9 +17,9 @@ use std::vars::{
     get_os_indications, set_os_indications,
     get_os_indications_supported
 };
-use uefi::guid;
-use uefi::reset::ResetType;
-use uefi::status::{Error, Result, Status};
+use std::uefi::guid;
+use std::uefi::reset::ResetType;
+use std::uefi::status::{Error, Result, Status};
 
 use crate::display::{Display, ScaledDisplay, Output};
 use crate::image::{self, Image};

--- a/src/display.rs
+++ b/src/display.rs
@@ -4,8 +4,8 @@ use core::cell::Cell;
 use core::ops::Try;
 use orbclient::{Color, Mode, Renderer};
 use std::proto::Protocol;
-use uefi::graphics::{GraphicsOutput, GraphicsBltOp, GraphicsBltPixel};
-use uefi::guid::{Guid, GRAPHICS_OUTPUT_PROTOCOL_GUID};
+use std::uefi::graphics::{GraphicsOutput, GraphicsBltOp, GraphicsBltPixel};
+use std::uefi::guid::{Guid, GRAPHICS_OUTPUT_PROTOCOL_GUID};
 
 pub struct Output(pub &'static mut GraphicsOutput);
 

--- a/src/dmi.rs
+++ b/src/dmi.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use core::slice;
-use uefi::guid::GuidKind;
+use std::uefi::guid::GuidKind;
 
 pub fn dmi() -> Vec<dmi::Table> {
     for table in std::system_table().config_tables() {

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use core::char;
-use uefi::status;
-use uefi::text::TextInputKey;
+use std::uefi::status;
+use std::uefi::text::TextInputKey;
 
 pub fn wait_key() -> Result<char, status::Error> {
     let uefi = std::system_table();

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use uefi::status::Result;
-use uefi::text::TextInputKey;
+use std::uefi::status::Result;
+use std::uefi::text::TextInputKey;
 
 pub fn raw_key() -> Result<TextInputKey> {
     let uefi = std::system_table();

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,9 @@ use std::prelude::*;
 
 use core::ops::{ControlFlow, Try};
 use core::ptr;
-use uefi::reset::ResetType;
-use uefi::status::{Result, Status};
+use std::uefi;
+use std::uefi::reset::ResetType;
+use std::uefi::status::{Result, Status};
 
 mod app;
 mod display;

--- a/src/null.rs
+++ b/src/null.rs
@@ -2,11 +2,11 @@
 
 use core::mem;
 use core::ops::Deref;
-use uefi::Handle;
-use uefi::boot::InterfaceType;
-use uefi::guid::SIMPLE_TEXT_OUTPUT_GUID;
-use uefi::status::{Result, Status};
-use uefi::text::TextOutputMode;
+use std::uefi::Handle;
+use std::uefi::boot::InterfaceType;
+use std::uefi::guid::SIMPLE_TEXT_OUTPUT_GUID;
+use std::uefi::status::{Result, Status};
+use std::uefi::text::TextOutputMode;
 
 #[repr(C)]
 #[allow(non_snake_case)]

--- a/src/text.rs
+++ b/src/text.rs
@@ -4,11 +4,11 @@ use core::{char, mem};
 use core::ops::Deref;
 use orbclient::{Color, Renderer};
 use std::proto::Protocol;
-use uefi::Handle;
-use uefi::boot::InterfaceType;
-use uefi::guid::SIMPLE_TEXT_OUTPUT_GUID;
-use uefi::status::{Result, Status};
-use uefi::text::TextOutputMode;
+use std::uefi::Handle;
+use std::uefi::boot::InterfaceType;
+use std::uefi::guid::SIMPLE_TEXT_OUTPUT_GUID;
+use std::uefi::status::{Result, Status};
+use std::uefi::text::TextOutputMode;
 
 use crate::display::{Display, ScaledDisplay, Output};
 


### PR DESCRIPTION
`uefi_std` re-exports `uefi`. Adding it as a separate dependency may cause import conflicts.
