### PR TITLE
Update toolchain to 2022-03-18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.106"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "orbclient"
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "redox_hwio"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b3b8075af56e2600f1bc43e97cb3911b8320d89d39a6215739c3cfff91af016"
+checksum = "9489d9e1b95e30ca0c6c5e9f5af5960ef838e4045eecd71db748248a7216778d"
 
 [[package]]
 name = "redox_intelflash"
@@ -80,24 +80,24 @@ dependencies = [
 
 [[package]]
 name = "redox_uefi"
-version = "0.1.2"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c63a3180c5aba47178029b21c1615fbdf87d2bf682669708ea15e9c71eb8935"
+checksum = "8b317cf652e12b060987e810efe95d61d8bcd157943731c7fa66897934d92d24"
 
 [[package]]
 name = "redox_uefi_alloc"
-version = "0.1.2"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524f31a58708b6d0ba2d4e734c1dcf14d287307b09118ff07ef25dd504773c7c"
+checksum = "9f4ea6b35d7f7ed38a82b7af61abccef31bc8f54912d00b2220e35d07423a775"
 dependencies = [
  "redox_uefi",
 ]
 
 [[package]]
 name = "redox_uefi_std"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a520781d9bb97c9802dd196e7a550fafaeea62d94b2351422c3424981d3a2d"
+checksum = "01adab1a733baa2f30e4db0ca0ef7747b936ab27690cecffda3027b5262d4600"
 dependencies = [
  "redox_uefi",
  "redox_uefi_alloc",
@@ -105,13 +105,13 @@ dependencies = [
 
 [[package]]
 name = "system76_ecflash"
-version = "0.1.2"
-source = "git+https://github.com/system76/ecflash.git#b08db293137726bc576da6bef6d57adf3e4adc97"
+version = "0.1.3"
+source = "git+https://github.com/system76/ecflash.git#2b94b81b971dce74f11fc8549fa8d6c4acd68657"
 
 [[package]]
 name = "system76_ectool"
-version = "0.3.6"
-source = "git+https://github.com/system76/ec.git#55a617f2e0c4bd4db7ea45fb5dba71addd9461ad"
+version = "0.3.8"
+source = "git+https://github.com/system76/ec.git#01885609e80cd66d809711ab49c23dbb68f9f6eb"
 dependencies = [
  "downcast-rs",
  "redox_hwio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ coreboot-fs = "0.1.0"
 intel-spi = "0.1.4"
 plain = "0.2.3"
 redox_dmi = "0.1.5"
-redox_hwio = "0.1.4"
+redox_hwio = "0.1.5"
 redox_intelflash = "0.1.3"
-redox_uefi_std = "0.1.5"
+redox_uefi_std = "0.1.8"
 system76_ecflash = { git = "https://github.com/system76/ecflash.git" }
 system76_ectool = { git = "https://github.com/system76/ec.git", default-features = false, features = ["redox_hwio"] }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-06-15"
+channel = "nightly-2022-03-18"
 components = ["rust-src", "clippy"]

--- a/src/app/bios.rs
+++ b/src/app/bios.rs
@@ -2,6 +2,7 @@
 
 use alloc::collections::BTreeMap;
 use alloc::string::String;
+use core::arch::asm;
 use core::char;
 use coreboot_fs::Rom;
 use ecflash::EcFlash;

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+use core::arch::asm;
 use core::cell::Cell;
 use core::ops::Try;
 use orbclient::{Color, Mode, Renderer};

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(asm)]
 #![feature(prelude_import)]
 #![feature(try_trait_v2)]
 #![feature(control_flow_enum)]


### PR DESCRIPTION
Match the toolchain used by Redox.

- Requires new release of system76_ecflash with system76/ecflash#5.
- Requires new release of redox-os/uefi_std with [redox-os/uefi#10](https://gitlab.redox-os.org/redox-os/uefi/-/merge_requests/10).