### PR TITLE
Pass /K for updating base board DMI info

### DIFF
--- a/res/firmware.nsh
+++ b/res/firmware.nsh
@@ -106,7 +106,7 @@ if "%2" == "bios" then
 
         # Flash with msiefiflash and exit if possible
         if exist msiefiflash.efi then
-            msiefiflash.efi firmware.rom
+            msiefiflash.efi firmware.rom /K
             exit %lasterror%
         endif
 


### PR DESCRIPTION
This should fix the Base Board Info DMI section not updating on thelio-b4 during firmware flash