### PR TITLE
Add /RLC:E parameter to msiefiflash

### DIFF
--- a/res/firmware.nsh
+++ b/res/firmware.nsh
@@ -114,7 +114,7 @@ if "%2" == "bios" then
         # Flash with msiefiflash and exit if possible
         # For: thelio-b4
         if exist msiefiflash.efi then
-            msiefiflash.efi firmware.rom /K
+            msiefiflash.efi firmware.rom /K /RLC:E
             exit %lasterror%
         endif
 


### PR DESCRIPTION
Eliminates a confusing prompt for user input