### PR TITLE
Match GUID directly

### DIFF
--- a/src/app/pci.rs
+++ b/src/app/pci.rs
@@ -1,7 +1,7 @@
 use core::{mem, slice};
 use hwio::{Io, Pio};
 use std::prelude::*;
-use std::uefi::guid::GuidKind;
+use std::uefi::guid;
 
 #[allow(dead_code)]
 #[repr(packed)]
@@ -82,8 +82,8 @@ unsafe fn rsdp_mcfg(rsdp: &Rsdp) -> Option<&'static [u8]> {
 
 pub fn pci_mcfg() -> Option<&'static [u8]> {
     for table in std::system_table().config_tables() {
-        match table.VendorGuid.kind() {
-            GuidKind::Acpi | GuidKind::Acpi2 => unsafe {
+        match table.VendorGuid {
+            guid::ACPI_TABLE_GUID | guid::ACPI_20_TABLE_GUID => unsafe {
                 let rsdp = &*(table.VendorTable as *const Rsdp);
                 if let Some(some) = rsdp_mcfg(rsdp) {
                     return Some(some);

--- a/src/dmi.rs
+++ b/src/dmi.rs
@@ -2,12 +2,12 @@
 
 use core::slice;
 use std::prelude::*;
-use std::uefi::guid::GuidKind;
+use std::uefi::guid;
 
 pub fn dmi() -> Vec<dmi::Table> {
     for table in std::system_table().config_tables() {
-        let data_opt = match table.VendorGuid.kind() {
-            GuidKind::Smbios => unsafe {
+        let data_opt = match table.VendorGuid {
+            guid::SMBIOS_TABLE_GUID => unsafe {
                 let smbios = &*(table.VendorTable as *const dmi::Smbios);
                 //TODO: smbios is_valid fails on bonw14, assume UEFI is right
                 Some(slice::from_raw_parts(
@@ -15,7 +15,7 @@ pub fn dmi() -> Vec<dmi::Table> {
                     smbios.table_length as usize,
                 ))
             },
-            GuidKind::Smbios3 => unsafe {
+            guid::SMBIOS3_TABLE_GUID => unsafe {
                 let smbios = &*(table.VendorTable as *const dmi::Smbios3);
                 //TODO: smbios is_valid fails on bonw14, assume UEFI is right
                 Some(slice::from_raw_parts(


### PR DESCRIPTION
Drop the use of `GuidKind` and compare GUIDs directly.

Ref: [redox-os/uefi#4](https://gitlab.redox-os.org/redox-os/uefi/-/issues/4)