### PR TITLE
Defer unlock prompt until update is accepted

### DIFF
--- a/src/app/ec.rs
+++ b/src/app/ec.rs
@@ -448,7 +448,7 @@ unsafe fn flash_legacy(firmware_data: &[u8]) -> core::result::Result<(), ectool:
     Ok(())
 }
 
-unsafe fn security_unlock() -> core::result::Result<(), ectool::Error> {
+pub unsafe fn security_unlock() -> core::result::Result<(), ectool::Error> {
     let access = AccessLpcDirect::new(UefiTimeout::new(100_000))?;
     let mut ec = ectool::Ec::new(access)?;
 
@@ -690,22 +690,6 @@ impl Component for EcComponent {
     }
 
     fn validate(&self) -> Result<bool> {
-        // If EC tag does not exist
-        if find(ECTAG).is_err() {
-            match &self.ec {
-                // Make sure EC is unlocked if running System76 EC
-                EcKind::System76(_, _) => match unsafe { security_unlock() } {
-                    Ok(()) => (),
-                    Err(err) => {
-                        println!("{} Failed to unlock: {:?}", self.name(), err);
-                        return Err(Error::DeviceError);
-                    }
-                },
-                // Assume EC is unlocked if not running System76 EC
-                _ => (),
-            }
-        }
-
         let data = load(self.path())?;
         Ok(self.validate_data(data))
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -268,6 +268,26 @@ fn inner() -> Result<()> {
 
         if c == '\n' || c == '\r' {
             success = true;
+
+            {
+                let ec_kind = unsafe { EcKind::new(true) };
+                // If EC tag does not exist, unlock the firmware
+                if find(ECTAG).is_err() {
+                    match ec_kind {
+                        // Make sure EC is unlocked if running System76 EC
+                        EcKind::System76(_, _) => match unsafe { ec::security_unlock() } {
+                            Ok(()) => (),
+                            Err(err) => {
+                                println!("Failed to unlock firmware: {:?}", err);
+                                return Err(Error::DeviceError);
+                            }
+                        },
+                        // Assume EC is unlocked if not running System76 EC
+                        _ => (),
+                    }
+                }
+            }
+
             for (component, validation) in components.iter().zip(validations.iter()) {
                 if *validation == ValidateKind::Found {
                     // Only shutdown if components are flashed


### PR DESCRIPTION
Move unlocking from EC validation to the main app update logic. This allows users to accept updating before unlocking, or cancel without unlocking.

This does not resolve the issue of returning to firmware-update when canceling/failing the unlock prompt, as the boot override still exists.

The UX for this needs additional improvements.

TEST:

- [x] Can successfully flash on a firmware-open board with firmware locking
- [x] Can successfully flash on a firmware-open board without firmware locking
- [ ] Can successfully flash on a proprietary firmware board

Resolves: #81
Partially resolves: https://github.com/system76/firmware-open/issues/405