### PR TITLE
Update CI and address clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,21 +8,20 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup Rust toolchain
       run: rustup show
 
-    - uses: actions-rs/clippy-check@v1
+    - name: clippy
       env:
         BASEDIR: "."
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+      run: cargo clippy
 
   build:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |

--- a/src/app/mapper.rs
+++ b/src/app/mapper.rs
@@ -8,7 +8,7 @@ impl Mapper for UefiMapper {
         address: PhysicalAddress,
         _size: usize,
     ) -> Result<VirtualAddress, &'static str> {
-        Ok(VirtualAddress(address.0 as usize))
+        Ok(VirtualAddress(address.0))
     }
 
     unsafe fn unmap_aligned(

--- a/src/display.rs
+++ b/src/display.rs
@@ -68,9 +68,9 @@ impl Display {
                 fast_copy(
                     data_ptr as *mut u8,
                     data_ptr.add(off1) as *const u8,
-                    off2 as usize * 4,
+                    off2 * 4,
                 );
-                fast_set32(data_ptr.add(off2), color.data, off1 as usize);
+                fast_set32(data_ptr.add(off2), color.data, off1);
             }
         }
     }

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -74,11 +74,6 @@ impl Image {
         })
     }
 
-    /// Create a new empty image
-    pub fn default() -> Self {
-        Self::new(0, 0)
-    }
-
     /// Get a piece of the image
     pub fn roi(&self, x: u32, y: u32, w: u32, h: u32) -> ImageRoi {
         let x1 = cmp::min(x, self.width());
@@ -103,6 +98,12 @@ impl Image {
     /// Draw the image on a window
     pub fn draw<R: Renderer>(&self, renderer: &mut R, x: i32, y: i32) {
         renderer.image_legacy(x, y, self.w, self.h, &self.data);
+    }
+}
+
+impl Default for Image {
+    fn default() -> Self {
+        Self::new(0, 0)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,9 @@
 #![allow(clippy::collapsible_if)]
 #![allow(clippy::many_single_char_names)]
 #![allow(clippy::missing_safety_doc)]
+#![allow(clippy::needless_range_loop)]
+#![allow(clippy::single_match)]
+#![allow(clippy::uninlined_format_args)]
 
 extern crate alloc;
 #[macro_use]

--- a/src/null.rs
+++ b/src/null.rs
@@ -97,7 +97,7 @@ impl NullDisplay {
             ClearScreen: clear_screen,
             SetCursorPosition: set_cursor_position,
             EnableCursor: enable_cursor,
-            Mode: unsafe { mem::transmute(&*mode.deref()) },
+            Mode: unsafe { mem::transmute(mode.deref()) },
 
             mode,
         }

--- a/src/text.rs
+++ b/src/text.rs
@@ -112,7 +112,7 @@ impl<'a> TextDisplay<'a> {
             ClearScreen: clear_screen,
             SetCursorPosition: set_cursor_position,
             EnableCursor: enable_cursor,
-            Mode: unsafe { mem::transmute(&*mode.deref()) },
+            Mode: unsafe { mem::transmute(mode.deref()) },
 
             mode,
             off_x: 0,
@@ -227,7 +227,7 @@ impl<'a> TextDisplay<'a> {
         if scrolled {
             let (cx, cw) = (0, self.display.width() as i32);
             let (cy, ch) = (self.off_y, self.rows as u32 * 16);
-            self.display.blit(cx, cy, cw as u32, ch as u32);
+            self.display.blit(cx, cy, cw as u32, ch);
         } else if changed {
             let (_x, y) = self.pos();
             let (cx, cw) = (0, self.display.width() as i32);


### PR DESCRIPTION
Update Actions:

- Update actions/checkout to v4
- Remove use of actions-rs

Allow the following warnings:

- clippy::needless_range_loop
- clippy::single_match
- clippy::uninlined_format_args

Fix the following warnings:

- clippy::borrow_deref_ref
- clippy::should_implement_trait
- clippy::unnecessary_cast
