### PR TITLE
Remove use of `prelude_import`

### DIFF
--- a/src/app/bios.rs
+++ b/src/app/bios.rs
@@ -9,6 +9,7 @@ use ecflash::EcFlash;
 use intel_spi::{HsfStsCtl, Spi, SpiDev};
 use plain::Plain;
 use std::fs::{find, load};
+use std::prelude::*;
 use std::ptr;
 use std::uefi::reset::ResetType;
 use std::uefi::status::{Error, Result, Status};

--- a/src/app/ec.rs
+++ b/src/app/ec.rs
@@ -4,6 +4,7 @@ use core::ops::{ControlFlow, Try};
 use ecflash::{Ec, EcFile, EcFlash};
 use ectool::{timeout, Access, AccessLpcDirect, Firmware, SecurityState, Spi, SpiRom, SpiTarget, Timeout};
 use plain::Plain;
+use std::prelude::*;
 use std::uefi::{
     self,
     reset::ResetType,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,6 +7,7 @@ use orbclient::{Color, Renderer};
 use std::exec::exec_path;
 use std::ffi::{nstr, wstr};
 use std::fs::{find, load};
+use std::prelude::*;
 use std::proto::Protocol;
 use std::uefi::guid;
 use std::uefi::reset::ResetType;

--- a/src/app/pci.rs
+++ b/src/app/pci.rs
@@ -1,5 +1,6 @@
 use core::{mem, slice};
 use hwio::{Io, Pio};
+use std::prelude::*;
 use std::uefi::guid::GuidKind;
 
 #[allow(dead_code)]

--- a/src/display.rs
+++ b/src/display.rs
@@ -4,6 +4,7 @@ use core::arch::asm;
 use core::cell::Cell;
 use core::ops::Try;
 use orbclient::{Color, Mode, Renderer};
+use std::prelude::*;
 use std::proto::Protocol;
 use std::uefi::graphics::{GraphicsBltOp, GraphicsBltPixel, GraphicsOutput};
 use std::uefi::guid::{Guid, GRAPHICS_OUTPUT_PROTOCOL_GUID};

--- a/src/dmi.rs
+++ b/src/dmi.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use core::slice;
+use std::prelude::*;
 use std::uefi::guid::GuidKind;
 
 pub fn dmi() -> Vec<dmi::Table> {

--- a/src/image/bmp.rs
+++ b/src/image/bmp.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::prelude::*;
+
 use super::Image;
 
 pub fn parse(file_data: &[u8]) -> Result<Image, String> {

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::prelude::*;
+
 use core::cell::Cell;
 use core::cmp;
 use core::prelude::v1::derive;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(prelude_import)]
 #![feature(try_trait_v2)]
 #![feature(control_flow_enum)]
 #![allow(clippy::collapsible_if)]
@@ -16,8 +15,6 @@ extern crate alloc;
 #[macro_use]
 extern crate uefi_std as std;
 
-#[allow(unused_imports)]
-#[prelude_import]
 use std::prelude::*;
 
 use core::ops::{ControlFlow, Try};

--- a/src/null.rs
+++ b/src/null.rs
@@ -2,6 +2,7 @@
 
 use core::mem;
 use core::ops::Deref;
+use std::prelude::*;
 use std::uefi::boot::InterfaceType;
 use std::uefi::guid::SIMPLE_TEXT_OUTPUT_GUID;
 use std::uefi::status::{Result, Status};

--- a/src/text.rs
+++ b/src/text.rs
@@ -3,6 +3,7 @@
 use core::ops::Deref;
 use core::{char, mem};
 use orbclient::{Color, Renderer};
+use std::prelude::*;
 use std::proto::Protocol;
 use std::uefi::boot::InterfaceType;
 use std::uefi::guid::SIMPLE_TEXT_OUTPUT_GUID;


### PR DESCRIPTION
Fixes the following warning:

```
warning: the feature `prelude_import` is internal to the compiler or standard library
 --> src/main.rs:5:12
  |
5 | #![feature(prelude_import)]
  |            ^^^^^^^^^^^^^^
  |
  = note: using it is strongly discouraged
  = note: `#[warn(internal_features)]` on by default
```