### PR TITLE
Update Rust toolchain to nightly-2024-05-11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,24 +110,24 @@ dependencies = [
 
 [[package]]
 name = "redox_uefi"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dbb9124e850a6953efb6ea3957d84fc48930a6dfd844d963bc8516c16f24e5"
+checksum = "ad1ef8d2afbe5adfc257e0847f360d0f175e7012c4fa984a284966b54ad5834d"
 
 [[package]]
 name = "redox_uefi_alloc"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ac0164918610031fe226ba74125aa03239eb86516131b8ee1e85de31b7c445"
+checksum = "12fe0357fd0ecc7c7de510c9add51a52a9268c3fa5890f9c8dbef890e4b2d1f6"
 dependencies = [
  "redox_uefi",
 ]
 
 [[package]]
 name = "redox_uefi_std"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e07da7709f8d1edbabf81657cd360886539c5c4a18fc047ed774bc1d6b466a"
+checksum = "2a19dfc2a64c4a152fff1819c6ce74460c322a46da9c812ffaa1282260c19ec2"
 dependencies = [
  "redox_uefi",
  "redox_uefi_alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ plain = "0.2.3"
 redox_dmi = "0.1.6"
 redox_hwio = { version = "0.1.6", default-features = false }
 redox_intelflash = "0.1.3"
-redox_uefi_std = "0.1.10"
+redox_uefi_std = "0.1.12"
 system76_ecflash = "0.1.3"
 
 [dependencies.system76_ectool]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-09-07"
+channel = "nightly-2024-05-11"
 components = ["rust-src", "clippy"]


### PR DESCRIPTION
Update toolchain to match the version used in Redox.