### PR TITLE
bios: Skip copying SMMSTORE

### DIFF
--- a/src/app/bios.rs
+++ b/src/app/bios.rs
@@ -362,6 +362,7 @@ impl Component for BiosComponent {
                 }
             }
 
+            /*
             // Copy old areas to new areas
             let area_names = ["SMMSTORE".to_string()];
             for area_name in &area_names {
@@ -414,6 +415,7 @@ impl Component for BiosComponent {
                     );
                 }
             }
+            */
 
             // Erase and write
             {


### PR DESCRIPTION
For testing if boot failure on gaze16 after update is caused by edk2 failing to use existing SMMSTORE.