### PR TITLE
ec: Use bonw15-b for new Bonobo name

### DIFF
--- a/src/app/ec.rs
+++ b/src/app/ec.rs
@@ -312,7 +312,8 @@ impl EcComponent {
                 "PE60SNx" => "system76/oryp12".to_string(),
                 "PDxxSNx" => "system76/serw13".to_string(),
                 "X170SM-G" => "system76/bonw14".to_string(),
-                "X370SNx" | "X370SNx1" => "system76/bonw15".to_string(),
+                "X370SNx" => "system76/bonw15".to_string(),
+                "X370SNx1" => "system76/bonw15-b".to_string(),
                 _ => model.to_string(),
             }
         };


### PR DESCRIPTION
The unit that was already flashed will either need to flash SBIOS+EC externally, or one-time hackfix the names to allow it to flash from `bonw15` to `bonw15-b`.