### PR TITLE
Remove soft-float flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,5 +51,4 @@ $(BUILD)/boot.efi: Cargo.lock Cargo.toml src/* src/*/*
 		--target $(TARGET) \
 		--release \
 		-- \
-		-C soft-float \
 		--emit link=$@


### PR DESCRIPTION
`-Csoft-float` is deprecated. Soft float is enabled by the target spec.

    $ rustc -Z unstable-options --target=x86_64-unknown-uefi --print target-spec-json | grep features
    "features": "-mmx,-sse,+soft-float",

Ref: https://github.com/rust-lang/rust/issues/129893
Resolves: #119