### PR TITLE
Misc cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup Rust toolchain
-      run: rustup show
+      run: rustup show active-toolchain || rustup toolchain install
 
     - name: clippy
       env:
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt install --yes make mtools parted
-        rustup show
+        rustup show active-toolchain || rustup toolchain install
 
     - name: Build UEFI application
       run: make

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-build
-firmware
-prefix
-target
+/build
+/firmware
+/target

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ firmware-update expects the firmware images to have specific names:
 
 The mechanism used to apply updates depends on the firmware image:
 
-- coreboot-based SBIOS: firmware-update flashes using [intel-spi](https://github.com/system76/intel-spi)
-- System76 EC: firmware-update flashes using [ecflash](https://github.com/system76/ecflash)
-- Proprietary: The vendor-provided tools are used
+- coreboot-based system firmware: [intel-spi](https://github.com/system76/intel-spi)
+- System76 EC: [ectool](https://github.com/system76/ec)
+- Proprietary: Vendor-provided tools

--- a/src/app/bios.rs
+++ b/src/app/bios.rs
@@ -407,7 +407,7 @@ impl Component for BiosComponent {
                             area_name
                         );
                     }
-                } else if areas.get(area_name).is_some() {
+                } else if areas.contains_key(area_name) {
                     println!(
                         "{}: found in old firmware, but not found in new firmware",
                         area_name

--- a/src/app/bios.rs
+++ b/src/app/bios.rs
@@ -387,7 +387,9 @@ impl Component for BiosComponent {
                             new_offset,
                             new_size / 1024
                         );
-                        let slice = data.get(offset..offset + size).ok_or(Status::DEVICE_ERROR)?;
+                        let slice = data
+                            .get(offset..offset + size)
+                            .ok_or(Status::DEVICE_ERROR)?;
 
                         if slice.len() == new_slice.len() {
                             new_slice.copy_from_slice(slice);
@@ -487,7 +489,9 @@ impl Component for BiosComponent {
 
             // Have coreboot reset the option table to the defaults.
             let mut cmos_options = cmos::CmosOptionTable::new();
-            unsafe { cmos_options.invalidate_checksum(); }
+            unsafe {
+                cmos_options.invalidate_checksum();
+            }
         } else {
             find(FIRMWARENSH)?;
 

--- a/src/app/mapper.rs
+++ b/src/app/mapper.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 use intel_spi::{Mapper, PhysicalAddress, VirtualAddress};
 
 pub struct UefiMapper;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -9,8 +9,8 @@ use std::prelude::*;
 use std::proto::Protocol;
 use std::uefi::reset::ResetType;
 use std::vars::{
-    get_boot_current, get_boot_item, get_boot_next, get_boot_order,
-    set_boot_item, set_boot_next, set_boot_order,
+    get_boot_current, get_boot_item, get_boot_next, get_boot_order, set_boot_item, set_boot_next,
+    set_boot_order,
 };
 
 use crate::display::{Display, Output, ScaledDisplay};
@@ -159,7 +159,13 @@ fn reset_dmi() -> Result<()> {
         ))?;
 
         let empty = [];
-        Result::from((uefi.RuntimeServices.SetVariable)(wname.as_ptr(), &guid, attributes, 0, empty.as_ptr()))?;
+        Result::from((uefi.RuntimeServices.SetVariable)(
+            wname.as_ptr(),
+            &guid,
+            attributes,
+            0,
+            empty.as_ptr(),
+        ))?;
     }
 
     Ok(())
@@ -278,7 +284,9 @@ fn inner() -> Result<()> {
                     // XXX: Probably better to check for HECI device.
                     if cmos_options.me_state() {
                         println!("Disabling CSME for writing SPI flash");
-                        unsafe { cmos_options.set_me_state(false); }
+                        unsafe {
+                            cmos_options.set_me_state(false);
+                        }
 
                         println!("System will reboot in 5 seconds");
                         let _ = (std::system_table().BootServices.Stall)(5_000_000);
@@ -396,7 +404,12 @@ pub fn main() -> Result<()> {
         for i in 0..output.0.Mode.MaxMode {
             let mut mode_ptr = ::core::ptr::null_mut();
             let mut mode_size = 0;
-            Result::from((output.0.QueryMode)(output.0, i, &mut mode_size, &mut mode_ptr))?;
+            Result::from((output.0.QueryMode)(
+                output.0,
+                i,
+                &mut mode_size,
+                &mut mode_ptr,
+            ))?;
 
             let mode = unsafe { &mut *mode_ptr };
             let w = mode.HorizontalResolution;

--- a/src/app/pci.rs
+++ b/src/app/pci.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 use core::{mem, slice};
 use hwio::{Io, Pio};
 use std::prelude::*;

--- a/src/app/sideband.rs
+++ b/src/app/sideband.rs
@@ -17,7 +17,9 @@ pub struct Sideband {
 impl Sideband {
     pub unsafe fn new(sbreg_phys: usize) -> Self {
         // On UEFI, physical memory is identity mapped
-        Self { addr: sbreg_phys as u64 }
+        Self {
+            addr: sbreg_phys as u64,
+        }
     }
 
     #[must_use]

--- a/src/app/sideband.rs
+++ b/src/app/sideband.rs
@@ -1,6 +1,5 @@
-// Copyright 2018-2021 System76 <info@system76.com>
-//
 // SPDX-License-Identifier: GPL-3.0-only
+// Copyright 2018-2021 System76 <info@system76.com>
 
 use core::ptr;
 
@@ -14,6 +13,7 @@ pub struct Sideband {
     pub addr: u64,
 }
 
+#[allow(dead_code)]
 impl Sideband {
     pub unsafe fn new(sbreg_phys: usize) -> Self {
         // On UEFI, physical memory is identity mapped

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -60,7 +60,11 @@ impl Image {
     }
 
     /// Create a new image from a boxed slice of colors
-    pub fn from_data(width: u32, height: u32, data: Box<[Color]>) -> core::result::Result<Self, String> {
+    pub fn from_data(
+        width: u32,
+        height: u32,
+        data: Box<[Color]>,
+    ) -> core::result::Result<Self, String> {
         if (width * height) as usize != data.len() {
             return Err(
                 "not enough or too much data given compared to width and height".to_string(),

--- a/src/io.rs
+++ b/src/io.rs
@@ -8,7 +8,11 @@ pub fn wait_key() -> Result<char> {
     let uefi = std::system_table();
 
     let mut index = 0;
-    Result::from((uefi.BootServices.WaitForEvent)(1, &uefi.ConsoleIn.WaitForKey, &mut index))?;
+    Result::from((uefi.BootServices.WaitForEvent)(
+        1,
+        &uefi.ConsoleIn.WaitForKey,
+        &mut index,
+    ))?;
 
     let mut input = TextInputKey {
         ScanCode: 0,

--- a/src/key.rs
+++ b/src/key.rs
@@ -7,7 +7,11 @@ pub fn raw_key() -> Result<TextInputKey> {
     let uefi = std::system_table();
 
     let mut index = 0;
-    Result::from((uefi.BootServices.WaitForEvent)(1, &uefi.ConsoleIn.WaitForKey, &mut index))?;
+    Result::from((uefi.BootServices.WaitForEvent)(
+        1,
+        &uefi.ConsoleIn.WaitForKey,
+        &mut index,
+    ))?;
 
     let mut key = TextInputKey {
         ScanCode: 0,

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+#![allow(clippy::missing_transmute_annotations)]
+
 use core::ops::Deref;
 use core::{char, mem};
 use orbclient::{Color, Renderer};
@@ -14,15 +16,15 @@ use crate::display::{Display, Output, ScaledDisplay};
 #[repr(C)]
 #[allow(non_snake_case)]
 pub struct TextDisplay<'a> {
-    pub Reset: extern "win64" fn(&mut TextDisplay, bool) -> Status,
-    pub OutputString: extern "win64" fn(&mut TextDisplay, *const u16) -> Status,
-    pub TestString: extern "win64" fn(&mut TextDisplay, *const u16) -> Status,
-    pub QueryMode: extern "win64" fn(&mut TextDisplay, usize, &mut usize, &mut usize) -> Status,
-    pub SetMode: extern "win64" fn(&mut TextDisplay, usize) -> Status,
-    pub SetAttribute: extern "win64" fn(&mut TextDisplay, usize) -> Status,
-    pub ClearScreen: extern "win64" fn(&mut TextDisplay) -> Status,
-    pub SetCursorPosition: extern "win64" fn(&mut TextDisplay, usize, usize) -> Status,
-    pub EnableCursor: extern "win64" fn(&mut TextDisplay, bool) -> Status,
+    pub Reset: extern "efiapi" fn(&mut TextDisplay, bool) -> Status,
+    pub OutputString: extern "efiapi" fn(&mut TextDisplay, *const u16) -> Status,
+    pub TestString: extern "efiapi" fn(&mut TextDisplay, *const u16) -> Status,
+    pub QueryMode: extern "efiapi" fn(&mut TextDisplay, usize, &mut usize, &mut usize) -> Status,
+    pub SetMode: extern "efiapi" fn(&mut TextDisplay, usize) -> Status,
+    pub SetAttribute: extern "efiapi" fn(&mut TextDisplay, usize) -> Status,
+    pub ClearScreen: extern "efiapi" fn(&mut TextDisplay) -> Status,
+    pub SetCursorPosition: extern "efiapi" fn(&mut TextDisplay, usize, usize) -> Status,
+    pub EnableCursor: extern "efiapi" fn(&mut TextDisplay, bool) -> Status,
     pub Mode: &'static TextOutputMode,
 
     pub mode: Box<TextOutputMode>,
@@ -33,22 +35,22 @@ pub struct TextDisplay<'a> {
     pub display: ScaledDisplay<'a>,
 }
 
-extern "win64" fn reset(_output: &mut TextDisplay, _extra: bool) -> Status {
+extern "efiapi" fn reset(_output: &mut TextDisplay, _extra: bool) -> Status {
     Status(0)
 }
 
-extern "win64" fn output_string(output: &mut TextDisplay, string: *const u16) -> Status {
+extern "efiapi" fn output_string(output: &mut TextDisplay, string: *const u16) -> Status {
     unsafe {
         output.write(string);
     }
     Status(0)
 }
 
-extern "win64" fn test_string(_output: &mut TextDisplay, _string: *const u16) -> Status {
+extern "efiapi" fn test_string(_output: &mut TextDisplay, _string: *const u16) -> Status {
     Status(0)
 }
 
-extern "win64" fn query_mode(
+extern "efiapi" fn query_mode(
     output: &mut TextDisplay,
     _mode: usize,
     columns: &mut usize,
@@ -59,21 +61,21 @@ extern "win64" fn query_mode(
     Status(0)
 }
 
-extern "win64" fn set_mode(_output: &mut TextDisplay, _mode: usize) -> Status {
+extern "efiapi" fn set_mode(_output: &mut TextDisplay, _mode: usize) -> Status {
     Status(0)
 }
 
-extern "win64" fn set_attribute(output: &mut TextDisplay, attribute: usize) -> Status {
+extern "efiapi" fn set_attribute(output: &mut TextDisplay, attribute: usize) -> Status {
     output.mode.Attribute = attribute as i32;
     Status(0)
 }
 
-extern "win64" fn clear_screen(output: &mut TextDisplay) -> Status {
+extern "efiapi" fn clear_screen(output: &mut TextDisplay) -> Status {
     output.clear();
     Status(0)
 }
 
-extern "win64" fn set_cursor_position(
+extern "efiapi" fn set_cursor_position(
     output: &mut TextDisplay,
     column: usize,
     row: usize,
@@ -82,7 +84,7 @@ extern "win64" fn set_cursor_position(
     Status(0)
 }
 
-extern "win64" fn enable_cursor(output: &mut TextDisplay, enable: bool) -> Status {
+extern "efiapi" fn enable_cursor(output: &mut TextDisplay, enable: bool) -> Status {
     output.mode.CursorVisible = enable;
     Status(0)
 }


### PR DESCRIPTION
- readme: fix method used for flashing System76 EC
- rework Make targets
- add missing SPDX IDs
- handle installing toolchain with rustup 1.28.0
- replace win64 with efiapi for ABI
- clippy
  - ignore: `dead_code`
  - ignore: `clippy::missing_transmute_annotations`
  - fix: `clippy::unnecessary_get_then_check`

Does not address `static_mut_refs`, which will be a hard error in the 2024 edition.

NOTE: The default target is changed from the FAT32 image to the UEFI application. Scripts relying on the default target will need to be updated.