### PR TITLE
Update toolchain, deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "coreboot-fs"
@@ -25,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "downcast-rs"
-version = "1.2.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "intel-spi"
@@ -35,7 +35,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b6b3b6a047aa89b5e4b0e98749a3a0e08481f1f54d22838d0c16a4233dc39df"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.1",
  "coreboot-fs",
  "libc",
  "redox_intelflash",
@@ -43,27 +43,29 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.1",
  "libc",
+ "plain",
  "redox_syscall",
 ]
 
 [[package]]
 name = "orbclient"
-version = "0.3.48"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba0b26cec2e24f08ed8bb31519a9333140a6599b867dac464bb150bdb796fd43"
+checksum = "59aed3b33578edcfa1bc96a321d590d31832b6ad55a26f0313362ce687e9abd6"
 dependencies = [
+ "libc",
  "libredox",
 ]
 
@@ -101,33 +103,33 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "redox_uefi"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d69301333534a04b380995f5d9e604f46a7cbd8d8c62c996ee27447efdeba4"
+checksum = "2e8148374036fd1a1f4d1184c4380dfdf1e7bbe2c43b3aa23a5358521c32c902"
 
 [[package]]
 name = "redox_uefi_alloc"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df364cdf289d9df9201f147aeeb5e7387f29f0824bee2e41e960eb98eaf03f1"
+checksum = "389b000bcb58fb4c5fc27092ed94d1fcc96ae1f88a458c792d2c2a6c29aeb249"
 dependencies = [
  "redox_uefi",
 ]
 
 [[package]]
 name = "redox_uefi_std"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b81203f45b2e08804d80274a2951f1615828d9aa5629d3a5d267878c70feb96d"
+checksum = "d7adba90fc68496a02cadacccff2f147830e74daace826df5eacce2a5b8ffcd3"
 dependencies = [
  "redox_uefi",
  "redox_uefi_alloc",
@@ -142,7 +144,7 @@ checksum = "3b4428b459c1c06e7a3ecf1dd3e863f4e7442a474463094af6a702e3b860ec25"
 [[package]]
 name = "system76_ectool"
 version = "0.3.8"
-source = "git+https://github.com/system76/ec.git#05744acaa684be64774470d95ef44905242b17e9"
+source = "git+https://github.com/system76/ec.git#ef05e145d554f4a4862258f582bbc309853ac606"
 dependencies = [
  "downcast-rs",
  "redox_hwio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ lto = true
 [dependencies]
 coreboot-fs = "0.1.1"
 intel-spi = "0.1.7"
-orbclient = { version = "0.3.46", default-features = false, features = ["unifont"] }
+orbclient = { version = "=0.3.51", default-features = false, features = ["unifont"] }
 plain = "0.2.3"
 redox_dmi = "0.1.6"
 redox_hwio = { version = "0.1.6", default-features = false }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.95.0"
 components = ["clippy"]
 targets = ["x86_64-unknown-uefi"]
 profile = "minimal"

--- a/src/app/ec.rs
+++ b/src/app/ec.rs
@@ -416,7 +416,7 @@ impl<T: Timeout> SpiLegacy<T> {
             for i in 0..block_size {
                 let byte = unsafe { self.pmc_read()? };
                 let addr = block * block_size + i;
-                if addr % self.page_size() == 0 {
+                if addr.is_multiple_of(self.page_size()) {
                     print!("\r{}%", (addr * 100) / (blocks * block_size));
                 }
                 if addr < data.len() {
@@ -441,7 +441,7 @@ impl<T: Timeout> SpiLegacy<T> {
             }
             for i in 0..block_size {
                 let addr = block * block_size + i;
-                if addr % self.page_size() == 0 {
+                if addr.is_multiple_of(self.page_size()) {
                     print!("\r{}%", (addr * 100) / (blocks * block_size));
                 }
                 let byte = if addr < data.len() { data[addr] } else { 0xFF };
@@ -460,7 +460,7 @@ unsafe fn flash_legacy(firmware_data: &[u8]) -> core::result::Result<(), ectool:
 
     // XXX: Get flash size programatically?
     let rom_size = new_rom.len();
-    if rom_size % 1024 != 0 {
+    if !rom_size.is_multiple_of(1024) {
         println!("ROM size of {} is not valid", rom_size);
         return Err(ectool::Error::Verify);
     }
@@ -596,7 +596,7 @@ unsafe fn flash(
 
     // XXX: Get flash size programatically?
     let rom_size = new_rom.len();
-    if rom_size % 1024 != 0 {
+    if !rom_size.is_multiple_of(1024) {
         println!("ROM size of {} is not valid", rom_size);
         return Err(ectool::Error::Verify);
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -226,7 +226,7 @@ fn inner() -> Result<()> {
         .any(|v| *v != ValidateKind::Found && *v != ValidateKind::NotFound)
     {
         "! Errors were found !"
-    } else if !validations.iter().any(|v| *v == ValidateKind::Found) {
+    } else if !validations.contains(&ValidateKind::Found) {
         "* No updates were found *"
     } else {
         let c = if let Ok((_, ectag)) = find(ECTAG) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -138,7 +138,7 @@ fn reset_dmi() -> Result<()> {
                 _ => return Err(status),
             }
         }
-        let name_str = nstr(name.as_mut_ptr());
+        let name_str = unsafe { nstr(name.as_mut_ptr()) };
         if name_str.starts_with("DmiVar") {
             vars.push((name_str, guid));
         }

--- a/src/display.rs
+++ b/src/display.rs
@@ -5,13 +5,12 @@ use orbclient::{Color, Mode, Renderer};
 use std::prelude::*;
 use std::proto::Protocol;
 use std::uefi::graphics::{GraphicsBltOp, GraphicsBltPixel, GraphicsOutput};
-use std::uefi::guid::GRAPHICS_OUTPUT_PROTOCOL_GUID;
 
 pub struct Output(pub &'static mut GraphicsOutput);
 
 impl Protocol<GraphicsOutput> for Output {
     fn guid() -> Guid {
-        GRAPHICS_OUTPUT_PROTOCOL_GUID
+        GraphicsOutput::GUID
     }
 
     fn new(inner: &'static mut GraphicsOutput) -> Self {

--- a/src/image/bmp.rs
+++ b/src/image/bmp.rs
@@ -37,8 +37,8 @@ pub fn parse(file_data: &[u8]) -> core::result::Result<Image, String> {
         let height = getd(0x16);
         let depth = getw(0x1C) as u32;
 
-        let bytes = (depth + 7) / 8;
-        let row_bytes = (depth * width + 31) / 32 * 4;
+        let bytes = depth.div_ceil(8);
+        let row_bytes = (depth * width).div_ceil(32) * 4;
 
         let mut blue_mask = 0xFF;
         let mut green_mask = 0xFF00;

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -80,7 +80,7 @@ impl Image {
     }
 
     /// Get a piece of the image
-    pub fn roi(&self, x: u32, y: u32, w: u32, h: u32) -> ImageRoi {
+    pub fn roi(&self, x: u32, y: u32, w: u32, h: u32) -> ImageRoi<'_> {
         let x1 = cmp::min(x, self.width());
         let y1 = cmp::min(y, self.height());
         let x2 = cmp::max(x1, cmp::min(x + w, self.width()));

--- a/src/text.rs
+++ b/src/text.rs
@@ -8,8 +8,7 @@ use orbclient::{Color, Renderer};
 use std::prelude::*;
 use std::proto::Protocol;
 use std::uefi::boot::InterfaceType;
-use std::uefi::guid::SIMPLE_TEXT_OUTPUT_GUID;
-use std::uefi::text::TextOutputMode;
+use std::uefi::text::{TextOutput, TextOutputMode};
 
 use crate::display::{Display, Output, ScaledDisplay};
 
@@ -247,7 +246,7 @@ impl<'a> TextDisplay<'a> {
         let mut stdout_handle = Handle(0);
         Result::from((uefi.BootServices.InstallProtocolInterface)(
             &mut stdout_handle,
-            &SIMPLE_TEXT_OUTPUT_GUID,
+            &TextOutput::GUID,
             InterfaceType::Native,
             stdout as usize,
         ))?;
@@ -271,7 +270,7 @@ impl<'a> TextDisplay<'a> {
 
         let _ = (uefi.BootServices.UninstallProtocolInterface)(
             stdout_handle,
-            &SIMPLE_TEXT_OUTPUT_GUID,
+            &TextOutput::GUID,
             stdout as usize,
         );
 


### PR DESCRIPTION
Update toolchain from 1.85.0 to 1.95.0.

Fix the following lints:

- `deprecated`
- `mismatched_lifetime_syntaxes`
- `clippy::manual_contains`
- `clippy::manual_div_ceil`
- `clippy::manual_is_multiple_of`